### PR TITLE
OP-3519: Add permissions block to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,14 @@ on:
     branches:
       - "feature/**"
   workflow_dispatch:
-  
+
+permissions: read-all
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v2

--- a/plans/OP-3519.md
+++ b/plans/OP-3519.md
@@ -1,0 +1,153 @@
+# OP-3519: Code-quality sweep: stark-standards
+
+## Ticket Context
+
+- **Type:** Task
+- **Priority:** Medium
+- **Status:** In Progress
+- **Jira:** https://starktechgroup.atlassian.net/browse/OP-3519
+
+### Description
+
+Code-quality sweep — `stark-standards`. **1M tier — single-file fix.** 100% `actions/missing-workflow-permissions`. Recipe in `code-quality/docs/PATTERNS.md` applies.
+
+**Findings:** 1 medium CodeQL alert in 1 GitHub Actions workflow:
+
+- `.github/workflows/publish.yml` — 1 alert (line 10) — first occurrence of `publish.yml` in the sweep (likely npm/package publish flow)
+
+Cleared by adding top-level `permissions:` block plus per-job overrides where needed.
+
+### Acceptance Criteria
+
+- [ ] `publish.yml` has top-level `permissions: read-all` block
+- [ ] `build` job has explicit `contents: write` override (required by `mikeal/publish-to-github-action` to push regenerated `README.md` back to the branch — NOT `packages: write`; this workflow does not publish to a package registry)
+- [ ] CodeQL re-scan: 1 → 0
+- [ ] Publish workflow remains functional — verified empirically by feature-branch run (auto-commit from the action lands on the branch)
+- [ ] Feature branch GPG-signed, base `dev`
+
+### Related Context
+
+This ticket is part of a **fleet-wide sweep** clearing the `actions/missing-workflow-permissions` CodeQL alert across all Stark repos. Sibling tickets (all "6M cluster archetype" — standard Go-service template):
+
+- OP-3484 stark-nyiso-data-pump · OP-3489 stark-permission-service · OP-3490 stark-event-message-bus
+- OP-3493 stark-babbage · OP-3494 stark-data-quality-service · OP-3496 stark-index-service
+- OP-3497 stark-pjm-data-pump · OP-3498 stark-reporting-service · OP-3499 stark-search-service
+
+`stark-standards` is the **1M tier** — different from the 6M Go-service cluster because it's a docs-only repo with a single workflow.
+
+External references (likely live in a separate sweep-orchestration location, **not in this repo**):
+
+- `code-quality/docs/PATTERNS.md` — recipe: "Missing top-level workflow permissions block"
+- `code-quality/plans/projects/stark-standards.md` — per-repo plan
+- Master plan: `code-quality/plans/code-quality-plan.md`
+
+## Codebase Analysis
+
+### Repo Type
+
+Documentation-only repository. `_README.md` + `general/**/README.md` source files are compiled into `README.md` via `markdown-include`. Build is a single npm command. **No application code, no tests, no deps beyond `markdown-include` itself.**
+
+### Affected Files
+
+| File | Change |
+|------|--------|
+| `.github/workflows/publish.yml` | Add `permissions:` block (top-level + job-level) |
+
+That's it. The fix is single-file.
+
+### Existing Workflow Shape
+
+```yaml
+name: publish
+on:
+  push:
+    branches:
+      - "feature/**"
+  workflow_dispatch:
+
+jobs:
+  build:                        # ← only job
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2 (node 14)
+      - run: npm install
+      - run: npm install markdown-include --save
+      - run: node ./node_modules/markdown-include/bin/cli.js ./markdown.json
+      - id: extract_branch                                 # extracts branch name
+      - uses: mikeal/publish-to-github-action@master       # ← pushes README back
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ steps.extract_branch.outputs.branch }}
+```
+
+Single job (`build`) does both the build AND a git push-back via `mikeal/publish-to-github-action@master` (line 24). That step writes the regenerated `README.md` back to the feature branch — confirmed by CLAUDE.md ("It automatically rebuilds `README.md` and publishes changes back to the branch").
+
+### Test Coverage
+
+None — this is a docs repo. Verification is empirical: trigger the workflow on a feature branch and confirm it still successfully pushes the regenerated `README.md`.
+
+## Implementation Plan
+
+### Phase 1: Add permissions block
+
+- [ ] Edit `.github/workflows/publish.yml` to add explicit permissions
+  - Top-level: `permissions: read-all` — matches PATTERNS.md recipe and the four prior sweep PRs (OP-3467, OP-3469, OP-3475, OP-3477) for reviewer consistency
+  - Job-level on `build`: `permissions: contents: write` — required by `mikeal/publish-to-github-action@master` to push the regenerated README back to the branch
+  - **Files affected:** `.github/workflows/publish.yml`
+
+  **Resulting workflow shape:**
+  ```yaml
+  name: publish
+  on:
+    push:
+      branches:
+        - "feature/**"
+    workflow_dispatch:
+
+  permissions: read-all
+
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+      steps:
+        # ... unchanged
+  ```
+
+### Phase 2: Verification
+
+- [ ] **Static check:** `yamllint .github/workflows/publish.yml` (if available) or visual inspect
+- [ ] **Functional verification:** Push the feature branch and watch the GitHub Actions run
+  - Workflow should succeed
+  - `README.md` should be regenerated and pushed back to the feature branch
+  - Verify the auto-commit appears on `feature/OP-3519_code-quality-sweep-stark-standards`
+- [ ] **CodeQL re-scan:** confirm alert count drops 1 → 0 on the feature branch (CodeQL workflow runs automatically on push)
+
+### Phase 3: Ship
+
+- [ ] GPG-signed commit on `feature/OP-3519_code-quality-sweep-stark-standards`
+- [ ] PR targeting `dev` (per project conventions)
+- [ ] PR description references OP-3519 + the canonical sweep recipe
+
+## Resolved Decisions
+
+1. **Acceptance criteria mismatch — `packages: write` vs `contents: write`.** ✅ Resolved: scope is `contents: write`. The ticket AC was templated assuming an npm/registry publish flow; the actual workflow regenerates a markdown file and pushes it back to the branch via `mikeal/publish-to-github-action@master`. PR description must explicitly disclose the AC correction so reviewers don't bounce on a literal-AC match.
+
+2. **Top-level scope: `read-all` vs `contents: read`.** ✅ Resolved: `read-all`. Matches PATTERNS.md recipe verbatim and the four prior sweep PRs (OP-3467, OP-3469, OP-3475, OP-3477). Single-job workflow, so functional difference is nil; consistency-with-the-sweep wins on review-throughput grounds.
+
+## Open Questions
+
+1. **`mikeal/publish-to-github-action@master` is unpinned and ancient.** Out of scope for this ticket (which is permissions-only) but worth surfacing — using `@master` violates standard supply-chain hygiene (`actions/checkout@v2` and `actions/setup-node@v2` + `node-version: '14'` are also outdated/EOL). Recommend a follow-up ticket for action pinning + version bumps. **Do not bundle into this PR** — keeps the diff minimal and reviewable. Note in PR description.
+
+2. **Verification: does `mikeal/publish-to-github-action` still work after the perms change?** Adding explicit `permissions` is technically *more restrictive* than the implicit default token. If we get the scope wrong (e.g., the action also needs `metadata: read` or similar), the publish step will silently start failing. Mitigation: real run on the feature branch confirms — do NOT merge before that runs green and the auto-commit lands.
+
+## Guardrails
+
+- **Repo build pipeline:** any change to `_README.md` or `general/**` requires running `npx markdown-include ./markdown.json` and committing the regenerated `README.md`. **This ticket touches neither**, so no rebuild needed — but watch for accidental edits.
+- **Never edit `README.md` directly** (per CLAUDE.md) — it's regenerated.
+- **Branch convention:** `feature/*` or `bug/*`. Already on `feature/OP-3519_code-quality-sweep-stark-standards`.
+- **PR base:** `dev`, not `main`.
+- **Commits:** must be GPG-signed.
+- **Permission keys to use exactly** (GitHub spec): `contents`, not `content`. `read` / `write` / `none` are the only valid values for top-level scopes.


### PR DESCRIPTION
## Summary

Clears CodeQL alert `actions/missing-workflow-permissions` on `.github/workflows/publish.yml` by adding an explicit top-level `permissions: read-all` block and a `contents: write` override on the `build` job. Follows the recipe shipped in OP-3467, OP-3469, OP-3475, and OP-3477.

CodeQL re-scan on the feature branch: **1 → 0** open alerts.

## Note on AC scope (please read before reviewing)

The ticket AC specifies `packages: write` on the publish job, assuming an npm/registry publish flow. **This workflow does not publish to a package registry** — it regenerates `README.md` via `markdown-include` and pushes the result back to the feature branch via `mikeal/publish-to-github-action`. The correct least-privilege scope for that operation is `contents: write`, not `packages: write`. CodeQL's `actions/missing-workflow-permissions` rule is satisfied either way; this aligns the scope with the actual operation.

## Changes

- `.github/workflows/publish.yml`: add `permissions: read-all` at the top, `permissions: { contents: write }` on the `build` job
- `plans/OP-3519.md`: ticket plan documenting the corrected AC and the design rationale (`read-all` chosen at the top to match the four prior sweep PRs)

## Pre-existing issue surfaced (NOT introduced by this PR — out of scope)

While verifying empirically, I discovered the publish workflow's auto-commit step has been silently broken since ~Feb 2023:

```
remote: error: GH006: Protected branch update failed
remote: - Commits must have verified signatures.
```

The `mikeal/publish-to-github-action` bot's commits are unsigned, and branch protection (`required_signatures: enabled`) rejects them. Last successful auto-publish commit in repo history is `dc16ae7` from `2023-02-10`; every `publish.yml` run on every `feature/**` branch in the past 7 months has failed for the same reason. The team has been manually committing README regenerations.

**This PR does NOT introduce that failure.** The workflow's runtime red status is identical before and after this change. The permissions block is functionally correct — the token now has the right scope, and the action's `git push` reaches the server and is rejected by branch protection (a different layer entirely: token scope vs. server-side rule). If my scope were wrong we'd see `403 Resource not accessible by integration` instead of `GH006`.

## Recommended follow-ups (separate tickets, intentionally NOT bundled here)

1. **Action version bump + pin** (medium priority): `actions/checkout@v2 → @v4`, `actions/setup-node@v2 → @v4` + `node-version: '14' → '20'`, replace or SHA-pin `mikeal/publish-to-github-action@master` (unmaintained, third-party, unpinned `@master` reference)
2. **Auto-publish push-back is broken** (low priority — team has worked around it manually): either remove the `mikeal/publish-to-github-action` step (effectively dead code), or wire up a signed-bot path (e.g., `crazy-max/ghaction-import-gpg` + a signing-capable bot identity)

## Verification

- `actionlint` clean on the permissions diff (the two pre-existing v2 deprecation warnings are noted above as out of scope)
- Feature branch pushed; CodeQL workflow re-scan completed successfully on this branch
- Open CodeQL alerts on branch: **0** (down from 1)
- Both commits GPG-signed (`Chris Michels`, key `C34924ED2C34C8D4`)

## Type

- [x] Enhancement (CI/CD hardening)
- [ ] Bug fix
- [ ] Dependency update

## Test Plan

- [x] CodeQL re-scan on feature branch returns 0 open `actions/missing-workflow-permissions` alerts
- [x] `actionlint` validates the permissions block parses
- [ ] Reviewer confirms scope rationale (`contents: write` vs the AC's `packages: write`) is acceptable given the actual workflow operation

---

jira:OP-3519
